### PR TITLE
Adding feature for local-data entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Variables
 | ``unbound_access_control``  | ``['access-control: 127.0.0.1 allow', 'access-control: ::1 allow']`` | define access control |
 | ``unbound__state`` | ``present`` | Package state. *(use ``latest`` for explicit update)*
 | ``submodules_versioncheck`` | ``false`` | run basic versions check. ``true`` is recomended. |
+| ``unbound__local_data`` | ``[]`` | Optional list of ``local-data`` entries to add into DNS configuration <br> e.g. "homeassistant.local A 10.10.0.22" |
 
 For more options have a look into the defaults/main.yml file.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ unbound_access_control:
   - 'access-control: 127.0.0.1 allow'
   - 'access-control: ::1 allow'
 
+# list of optional local-data entries
+unbound__local_data: []
+
 unbound__state: 'present'
 
 # snippets for dns rebinding protection

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -48,8 +48,8 @@
   ansible.builtin.file:
     path: '/etc/unbound/unbound.conf.d/local-data.conf'
     state: absent
+  notify: 'Systemctl restart unbound'
   when: unbound__local_data is not defined or unbound__local_data | length == 0
-    
 
 - name: Transfer main unbound configuration
   become: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -32,6 +32,25 @@
   notify: 'Systemctl restart unbound'
   when: unbound__auto_trust_anchor | bool
 
+- name: Copy local-data entries
+  become: true
+  ansible.builtin.template:
+    src: 'templates/snippets/local-data.conf'
+    dest: '/etc/unbound/unbound.conf.d/'
+    owner: root
+    group: root
+    mode: 'u=rw,g=r,o=r'
+  notify: 'Systemctl restart unbound'
+  when: unbound__local_data is defined and unbound__local_data | length > 0
+
+- name: Ensure local-data config file state
+  become: true
+  ansible.builtin.file:
+    path: '/etc/unbound/unbound.conf.d/local-data.conf'
+    state: absent
+  when: unbound__local_data is not defined or unbound__local_data | length == 0
+    
+
 - name: Transfer main unbound configuration
   become: true
   ansible.builtin.template:
@@ -42,3 +61,4 @@
     mode: 'u=rw,g=r,o=r'
     validate: unbound-checkconf %s
   notify: 'Systemctl restart unbound'
+...

--- a/templates/snippets/local-data.conf
+++ b/templates/snippets/local-data.conf
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 server:
-    # Add local-data entries for adding locally served DNS entries. As unbound
-    # servers as non-authoritative reverse DNS no CNAME/DNAME support is
+    # local-data entries for adding locally served DNS entries. As unbound
+    # serves as non-authoritative reverse DNS no CNAME/DNAME support is
     # available without the configuration of a stub-zone.
 
 {% for entry in unbound__local_data %}

--- a/templates/snippets/local-data.conf
+++ b/templates/snippets/local-data.conf
@@ -1,0 +1,9 @@
+{{ ansible_managed | comment }}
+server:
+    # Add local-data entries for adding locally served DNS entries. As unbound
+    # servers as non-authoritative reverse DNS no CNAME/DNAME support is
+    # available without the configuration of a stub-zone.
+
+{% for entry in unbound__local_data %}
+    local-data: "{{ entry }}"
+{% endfor %}


### PR DESCRIPTION
Hi @DO1JLR,

I've added a feature to this Ansible role which allows the user to configure `local-data` entries inside
the Unbound configuration.

---

A basic template variable has been added with

```yaml
# list of optional local-data entries
unbound__local_data: []
```

This can also be left empty or omitted, the configuration will consider the state of these
variables. They will be only inserted if defined, so idempotency should be preserved.

Configuring the entries can be done via adding the DNS configuration entry into the list:

```yaml
unbound__local_data: [
  "homeassistant.local A 10.0.0.25",
  "gitea.local A 10.0.0.20"
]
```

The host will receive an additional `local-data.conf` inside `unbound.conf.d` if any entries exist.

---

As of the nature of Unbound no CNAME/DNAME support is generally available (without stub-zones).
However, I added these because I also use a reverse-proxy and can configure individual domains there.

Within local networks I think this may be useful as we can define any arbitrary FQDN for some service running.
So adding some A entries for local networks is probably the main use-case for this
(or redirecting DNS queries to some other server on the Internet).
